### PR TITLE
Making line separators of uniform width and aligning footer.

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -49,6 +49,10 @@ footer {
     text-align: right;
 }
 
+footer.col-md-10 {
+    padding: 0;
+}
+
 fieldset {
     margin-top: 1em;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -48,7 +48,7 @@
                     {% block content %}{% endblock %}
                 </div>
             </div>
-            <footer><small>
+            <footer class="col-md-10"><small>
                 <hr>
                 <a href="https://twitter.com/happinesspacket" class="twitter-follow-button" data-show-count="false" data-size="large" data-dnt="true">Follow @happinesspacket</a>
                 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>


### PR DESCRIPTION
Hi,
This is a change that was suggested to our forked project of Fedora Happiness Packets.
It is a change that also could benefit this upstream happinesspackets project, and hence this PR is made.


**What is changed in this PR ?**
The current home page of [happinesspackets](https://www.happinesspackets.io/) has inconsintent line-separators, and the footer is also competely right aligned.
This gives an inconsistent visual experience.

This PR, once merged, will result in visual consistency on the homepage.

**How is the change made ?**
Two files have been slightly changed for addressing this issue.

1. `templates\base.html` : in this file, a bootstrap class of `col-md-10` is added to the `footer` element.
2. `assets\css\custom.css` : in this file a style rule of `padding: 0` has been added to `footer.col-md-10` to remove the unwanted padding that occured.

**Screenshots**

Current homepage:
![before---copy](https://user-images.githubusercontent.com/16290904/53547889-37266480-3b56-11e9-9025-9db211e2c26e.png)


Homepage after the proposed change:

![after - copy](https://user-images.githubusercontent.com/16290904/53547901-3c83af00-3b56-11e9-9481-76b7c361ebcd.png)


